### PR TITLE
Fixed a bug in upload_neuron's behavior with import_connectors=True, …

### DIFF
--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -557,7 +557,6 @@ def upload_neuron(x, import_tags=False, import_annotations=False,
 
         # First create new connectors
         cn_resp = add_connector(connectors_no_duplicates[['x', 'y', 'z']].values,
-                                check_existing=reuse_existing_connectors,
                                 remote_instance=remote_instance)
 
         resp['connector_response'] = cn_resp

--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -551,14 +551,19 @@ def upload_neuron(x, import_tags=False, import_annotations=False,
                                               remote_instance=remote_instance)
 
     if import_connectors and not x.connectors.empty:
+        #Connectors that make multiple links onto the neuron will be listed more than once,
+        #but only want to upload them once
+        connectors_no_duplicates = x.connectors.drop_duplicates(subset=['connector_id'])
+
         # First create new connectors
-        cn_resp = add_connector(x.connectors[['x', 'y', 'z']].values,
+        cn_resp = add_connector(connectors_no_duplicates[['x', 'y', 'z']].values,
+                                check_existing=reuse_existing_connectors,
                                 remote_instance=remote_instance)
 
         resp['connector_response'] = cn_resp
 
         # Create old to new IDs map
-        cn_map = {old: new['connector_id'] for old, new in zip(x.connectors.connector_id.values,
+        cn_map = {old: new['connector_id'] for old, new in zip(connectors_no_duplicates.connector_id.values,
                                                                cn_resp)}
 
         # Add map to server response


### PR DESCRIPTION
…where individual connectors linked twice to a single neuron would get uploaded twice. With this change, that type of multiply-linked connector is uploaded just once, but still linked as many times as it needs to be linked to the uploaded neuron.

Note that the connectors_no_duplicates object is used for the connector upload, but the x.connectors object is used for creating links, since each entry in x.connectors actually corresponds to a link.