### PR TITLE
Enabling sets as arguments to pymaid functions

### DIFF
--- a/pymaid/utils.py
+++ b/pymaid/utils.py
@@ -168,7 +168,7 @@ def _make_iterable(x, force_type=None):
     if not isinstance(x, collections.Iterable) or isinstance(x, six.string_types):
         x = [x]
 
-    if isinstance(x, dict):
+    if isinstance(x, dict) or isinstance(x, set):
         x = list(x)
 
     if force_type:


### PR DESCRIPTION
Sets could not previously be passed as arguments to functions that call _make_iterable due to _make_iterable not handling sets correctly. This commit just casts sets to lists within _make_iterable (in the same way that dicts get handled) so that sets get handled properly and can now be used as arguments to pymaid functions.