### PR TITLE
Improvement to upload_neuron's handling of connectors and connector tags

### DIFF
--- a/pymaid/core.py
+++ b/pymaid/core.py
@@ -136,6 +136,8 @@ class CatmaidNeuron:
                         Timestamp of data retrieval.
     tags :              dict
                         Treenode tags.
+    connector_tags :    dict
+                        Connector tags.
     annotations :       list
                         This neuron's annotations.
     graph :             ``network.DiGraph``
@@ -295,6 +297,7 @@ class CatmaidNeuron:
                           'nodes', 'annotations', 'partners', 'review_status',
                           'connectors', 'presynapses', 'postsynapses',
                           'gap_junctions', 'soma', 'root', 'tags',
+                          'connector_tags',
                           'n_presynapses', 'n_postsynapses', 'n_connectors',
                           'bbox']
 
@@ -353,6 +356,9 @@ class CatmaidNeuron:
         elif key == 'tags':
             self.get_skeleton()
             return self.tags
+        elif key == 'connector_tags':
+            self.get_connector_tags()
+            return self.connector_tags
         elif key == 'sampling_resolution':
             return self.n_nodes / self.cable_length
         elif key == 'n_open_ends':
@@ -523,19 +529,20 @@ class CatmaidNeuron:
 
 
     def get_connector_tags(self, remote_instance=None, **fetch_kwargs):
+        """
+        TODO
+        """
         if not remote_instance and not self._remote_instance:
-            raise Exception('Get_skeleton - Unable to connect to server '
-                            'without remote_instance. See '
+            raise Exception('get_connector_tags - Unable to connect to '
+                            'server without remote_instance. See '
                             'help(core.CatmaidNeuron) to learn how to '
                             'assign.')
         elif not remote_instance:
             remote_instance = self._remote_instance
+
         logger.info('Retrieving connector tags...')
-        connector_tags = fetch.get_connector_tags(self.skeleton_id,
-                                                  remote_instance=remote_instance,
-                                                  return_df=True,
-                                                  fetch_kwargs=fetch_kwargs).iloc[0]
-        self.connector_tags = connector_tags  # I doubt this will work
+        self.connector_tags = fetch.get_connector_tags(self,
+                                                       remote_instance=remote_instance)
 
         return
 

--- a/pymaid/core.py
+++ b/pymaid/core.py
@@ -1658,6 +1658,7 @@ class CatmaidNeuronList:
                      'n_postsynapses', 'n_open_ends', 'n_end_nodes',
                      'cable_length', 'tags', 'igraph', 'soma', 'root',
                      'segments', 'graph', 'n_branch_nodes', 'dps',
+                     'connector_tags',
                      'sampling_resolution']:
             self.get_skeletons(skip_existing=True)
             return np.array([getattr(n, key) for n in self.neurons])

--- a/pymaid/core.py
+++ b/pymaid/core.py
@@ -521,6 +521,25 @@ class CatmaidNeuron:
 
         return
 
+
+    def get_connector_tags(self, remote_instance=None, **fetch_kwargs):
+        if not remote_instance and not self._remote_instance:
+            raise Exception('Get_skeleton - Unable to connect to server '
+                            'without remote_instance. See '
+                            'help(core.CatmaidNeuron) to learn how to '
+                            'assign.')
+        elif not remote_instance:
+            remote_instance = self._remote_instance
+        logger.info('Retrieving connector tags...')
+        connector_tags = fetch.get_connector_tags(self.skeleton_id,
+                                                  remote_instance=remote_instance,
+                                                  return_df=True,
+                                                  fetch_kwargs=fetch_kwargs).iloc[0]
+        self.connector_tags = connector_tags  # I doubt this will work
+
+        return
+
+
     def _clear_temp_attr(self, exclude=[]):
         """Clear temporary attributes."""
         temp_att = ['igraph', 'graph', 'segments', 'small_segments',

--- a/pymaid/core.py
+++ b/pymaid/core.py
@@ -530,7 +530,9 @@ class CatmaidNeuron:
 
     def get_connector_tags(self, remote_instance=None, **fetch_kwargs):
         """
-        TODO
+        Get/update tags on connectors of a neuron. After running,
+        neuron.connector_tags will store a list of tag-node mappings
+        similar to neuron.tags.
         """
         if not remote_instance and not self._remote_instance:
             raise Exception('get_connector_tags - Unable to connect to '

--- a/pymaid/core.py
+++ b/pymaid/core.py
@@ -1658,9 +1658,8 @@ class CatmaidNeuronList:
             return (self.__len__(),)
         elif key in ['n_nodes', 'n_connectors', 'n_presynapses',
                      'n_postsynapses', 'n_open_ends', 'n_end_nodes',
-                     'cable_length', 'tags', 'igraph', 'soma', 'root',
+                     'cable_length', 'igraph', 'soma', 'root',
                      'segments', 'graph', 'n_branch_nodes', 'dps',
-                     'connector_tags',
                      'sampling_resolution']:
             self.get_skeletons(skip_existing=True)
             return np.array([getattr(n, key) for n in self.neurons])

--- a/pymaid/fetch.py
+++ b/pymaid/fetch.py
@@ -1456,7 +1456,7 @@ def get_connector_tags(x, remote_instance=None):
 
     cn_tags = {}
     for cnid in resp:
-        cn_tags.update({tag: cn_tags.get(tag, []) + [cnid] for tag in resp[cnid]})
+        cn_tags.update({tag: cn_tags.get(tag, []) + [int(cnid)] for tag in resp[cnid]})
 
     return cn_tags
 

--- a/pymaid/fetch.py
+++ b/pymaid/fetch.py
@@ -1440,8 +1440,21 @@ def get_connector_details(x, remote_instance=None):
 
 @cache.undo_on_error
 def get_connector_tags(x, remote_instance=None):
+    """Retrieve tags on sets of connectors.
 
-    #TODO DOCSTRING
+    Parameters
+    ----------
+    x :                 list of connector IDs | CatmaidNeuron | CatmaidNeuronList
+                        Connector ID(s) to retrieve details for. If
+                        CatmaidNeuron/List, will use their connectors.
+    remote_instance :   CatmaidInstance, optional
+                        If not passed directly, will try using global.
+
+    Returns
+    ---------
+    dict
+                        ``{tag1: [connector1_id, connector2_id, ...], tag2: [ ... ], ...}``
+    """
     remote_instance = utils._eval_remote_instance(remote_instance)
 
     connector_ids = utils.eval_node_ids(x, connectors=True, treenodes=False)

--- a/pymaid/fetch.py
+++ b/pymaid/fetch.py
@@ -58,6 +58,7 @@ from .intersect import in_volume
 __all__ = sorted(['get_annotation_details', 'get_annotation_id',
                   'get_annotation_list', 'get_annotations', 'get_arbor',
                   'get_connector_details', 'get_connectors',
+                  'get_connector_tags',
                   'get_contributor_statistics', 'get_edges', 'get_history',
                   'get_logs', 'get_names', 'get_neuron',
                   'get_neurons', 'get_neurons_in_bbox',
@@ -1435,6 +1436,28 @@ def get_connector_details(x, remote_instance=None):
                       )
 
     return df
+
+
+@cache.undo_on_error
+def get_connector_tags(x, remote_instance=None):
+
+    #TODO DOCSTRING
+    remote_instance = utils._eval_remote_instance(remote_instance)
+
+    connector_ids = utils.eval_node_ids(x, connectors=True, treenodes=False)
+
+    connector_ids = list(set(connector_ids))
+
+    remote_get_node_labels_url = remote_instance._get_node_labels_url()
+
+    POST = {key: ','.join([str(tn) for tn in connector_ids])}
+
+    response = remote_instance.fetch(remote_get_node_labels_url, post=POST)
+
+    #TODO flip repsonse dict from {connector_id: [tag1, tag2]} to like this:
+    # {'motor connection: [list, of, connector_ids, with, that, tag']}
+    connector_tags = response #TODO change this
+    return connector_tags
 
 
 @cache.undo_on_error

--- a/pymaid/fetch.py
+++ b/pymaid/fetch.py
@@ -1450,14 +1450,15 @@ def get_connector_tags(x, remote_instance=None):
 
     remote_get_node_labels_url = remote_instance._get_node_labels_url()
 
-    POST = {key: ','.join([str(tn) for tn in connector_ids])}
+    POST = {'connector_ids': ','.join([str(tn) for tn in connector_ids])}
 
-    response = remote_instance.fetch(remote_get_node_labels_url, post=POST)
+    resp = remote_instance.fetch(remote_get_node_labels_url, post=POST)
 
-    #TODO flip repsonse dict from {connector_id: [tag1, tag2]} to like this:
-    # {'motor connection: [list, of, connector_ids, with, that, tag']}
-    connector_tags = response #TODO change this
-    return connector_tags
+    cn_tags = {}
+    for cnid in resp:
+        cn_tags.update({tag: cn_tags.get(tag, []) + [cnid] for tag in resp[cnid]})
+
+    return cn_tags
 
 
 @cache.undo_on_error

--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -1725,7 +1725,10 @@ def add_connector(coords, check_existing=True, remote_instance=None):
         raise ValueError('Expected x/y/z coordinates, got {}'.format(coords.shape[1]))
     if check_existing:
         for coord in coords:
-            existing_connector = fetch.get_connectors_in_bbox([[coord[0],coord[0]+1],[coord[1],coord[1]+1],[coord[2],coord[2]+1]], ret='IDS',remote_instance=remote_instance)    
+            existing_connector = fetch.get_connectors_in_bbox([[coord[0], coord[0]+1],
+                                                               [coord[1], coord[1]+1],
+                                                               [coord[2], coord[2]+1]],
+                                                              ret='IDS', remote_instance=remote_instance)    
             
             if len(existing_connector) == 0:
                 url = [remote_instance._create_connector_url()] 

--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -1730,8 +1730,6 @@ def add_connector(coords, check_existing=True, remote_instance=None):
     """
     remote_instance = utils._eval_remote_instance(remote_instance)    
     resp = []
-    url = []
-    post = []
     if not utils._is_iterable(coords[0]):
         coords = [coords]
 
@@ -1747,15 +1745,15 @@ def add_connector(coords, check_existing=True, remote_instance=None):
                                                               ret='IDS', remote_instance=remote_instance)    
             
             if len(existing_connector) == 0:
-                url.extend([remote_instance._create_connector_url()]) 
-                post.extend([{'pid': remote_instance.project_id, 
+                url = [remote_instance._create_connector_url()] 
+                post = [{'pid': remote_instance.project_id, 
                         'confidence': 5,
                         'x': coord[0],
                         'y': coord[1],
-                        'z': coord[2]}])               
+                        'z': coord[2]}]
+                resp.extend(remote_instance.fetch(url, post=post, desc='Creating connectors'))
             else:
                 resp.extend([{'connector_id':existing_connector[0][0]}])
-        resp.extend(remote_instance.fetch(url, post=post, desc='Creating connectors'))
     else:
         url = [remote_instance._create_connector_url()] * coords.shape[0]
 

--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -1765,6 +1765,8 @@ def add_connector(coords, check_existing=True, remote_instance=None):
                         'x': coord[0],
                         'y': coord[1],
                         'z': coord[2]}]
+                # TODO run one API call for all connectors that need to be uploaded, instead of
+                # one call per connector. Single calls for many connectors are much faster.
                 resp.extend(remote_instance.fetch(url, post=post, desc='Creating connectors'))
             else:
                 resp.extend([{'connector_id':existing_connector[0][0]}])

--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -591,8 +591,6 @@ def upload_neuron(x, import_tags=False, import_annotations=False,
         resp['link_response'] = ln_resp
 
         if import_tags and getattr(x, 'connector_tags', {}):
-            #print(cn_map)
-            #print(x.connector_tags.items())
             # Map old to new connectors
             cn_tags = {t: [cn_map[n] for n in v] for t, v in x.connector_tags.items()}
             # Invert connector tag dictionary: map connctor ID -> list of tags
@@ -603,6 +601,7 @@ def upload_neuron(x, import_tags=False, import_annotations=False,
             resp['connector_tags'] = add_tags(list(ctags.keys()),
                                               ctags,
                                               'CONNECTOR',
+                                              override_existing=True,
                                               remote_instance=remote_instance)
 
     return resp

--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -1730,6 +1730,8 @@ def add_connector(coords, check_existing=True, remote_instance=None):
     """
     remote_instance = utils._eval_remote_instance(remote_instance)    
     resp = []
+    url = []
+    post = []
     if not utils._is_iterable(coords[0]):
         coords = [coords]
 
@@ -1745,15 +1747,15 @@ def add_connector(coords, check_existing=True, remote_instance=None):
                                                               ret='IDS', remote_instance=remote_instance)    
             
             if len(existing_connector) == 0:
-                url = [remote_instance._create_connector_url()] 
-                post = [{'pid': remote_instance.project_id, 
+                url.extend([remote_instance._create_connector_url()]) 
+                post.extend([{'pid': remote_instance.project_id, 
                         'confidence': 5,
                         'x': coord[0],
                         'y': coord[1],
-                        'z': coord[2]}]
-                resp.extend(remote_instance.fetch(url, post=post, desc='Creating connectors'))
+                        'z': coord[2]}])               
             else:
                 resp.extend([{'connector_id':existing_connector[0][0]}])
+        resp.extend(remote_instance.fetch(url, post=post, desc='Creating connectors'))
     else:
         url = [remote_instance._create_connector_url()] * coords.shape[0]
 

--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -319,7 +319,7 @@ def upload_neuron(x, import_tags=False, import_annotations=False,
     import_connectors :  bool, optional
                          If True will upload connectors from ``x.connectors``.
     reuse_existing_connectors : bool, optional
-                         Only matters when import_connetors is True.
+                         Only matters when import_connectors is True.
                          If True will look in the remote_instance at the
                          location of each of ``x``'s connectors, and if
                          present, ``x`` will be linked to that existing

--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -590,6 +590,21 @@ def upload_neuron(x, import_tags=False, import_annotations=False,
 
         resp['link_response'] = ln_resp
 
+        if import_tags and getattr(x, 'connector_tags', {}):
+            #print(cn_map)
+            #print(x.connector_tags.items())
+            # Map old to new connectors
+            cn_tags = {t: [cn_map[n] for n in v] for t, v in x.connector_tags.items()}
+            # Invert connector tag dictionary: map connctor ID -> list of tags
+            ctags = {}
+            for t in cn_tags:
+                ctags.update({n: ctags.get(n, []) + [t] for n in cn_tags[t]})
+
+            resp['connector_tags'] = add_tags(list(ctags.keys()),
+                                              ctags,
+                                              'CONNECTOR',
+                                              remote_instance=remote_instance)
+
     return resp
 
 


### PR DESCRIPTION
Closes #196 

Hey Philipp, finally getting around to trying to push you these changes I wrote a few months ago. The the motivation and logic for the new `reuse_existing_connectors`/`check_existing` parameters in `upload_neuron`/`add_connector` respectively are mostly described in the issue I opened above. Currently `upload_neuron`'s parameter named `reuse_existing_connectors` is just passed to `add_connector` as the `check_existing` argument (see [here](https://github.com/htem/pymaid/blob/upload-neuron-dev/pymaid/upload.py#L569).) I thought it made sense to give these parameters different names to clarify their purposes a bit for the two different functions, but they're functionally the same so could change them to be the same variable name if you think that'd be clearer.

With the new `check_existing` logic, `add_connector` unfortunately makes one catmaid API call for each connector to be uploaded. This is slow. It's much faster to have one API call for all the connectors that need to be uploaded. It's possible to code up logic that brings this function back to having one API call while still having `check_existing` happen, and I'm meaning to make a commit that accomplishes this in next few days, but wanted to open this pull request now to give you a chance to look at this and provide any feedback. I'll post here once I've gotten this last commit done, but don't accept the pull request before that happens please!

I additionally realized that connector tags were not being transferred, and I wanted this to happen too. To accomplish that, I had to add a new attribute `connector_tags` to `CatmaidNeuron` objects, since previously connector tags were not stored as part of `CatmaidNeuron`s and so were not easily able to be uploaded. For the most part I took the `tags` attribute code and modified it to build the `connector_tags` attribute. This new attribute behaves as I would expect it to, as far as I've been able to see; `myCatmaidNeuron.connector_tags` and `myCatmaidNeuronList.connector_tags` both return `dict`s that are equivalent in structure to what you get when you ask for `.tags`, but of course for connectors instead. Having implemented this, it was straightforward to get `upload_neuron` to upload those connector tags as well.

If it turns out to be a pain to have two features implemented in one pull request like I'm doing here, I can certainly split it up, but my hunch is that combining a few small features into one PR will work out just fine.