### PR TITLE
Fix response parsing 

### DIFF
--- a/pymaid/tests/test_pymaid.py
+++ b/pymaid/tests/test_pymaid.py
@@ -696,7 +696,7 @@ class TestGraphs(unittest.TestCase):
     @try_conditions
     def test_node_sorting(self):
         self.assertIsInstance(ns.graph.node_label_sorting(self.n),
-                              list)
+                              (list, np.ndarray))
 
     @try_conditions
     def test_geodesic_matrix(self):


### PR DESCRIPTION
This PR fixes #251 by looking for either `aaData` (pre `v2021.12.21`) or just `data` (post `v2021.12.21`) in responses from the CATMAID server.

Affected functions: `get_user_annotations`, `get_annotation_details`, `get_logs` and `get_volume`. The latter two were modified to play it safe - I don't actually know if there was an issue.

